### PR TITLE
Improve tracking setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # TFM
+
+This repository contains scripts to train a YOLOv8 model and perform object
+tracking using Deep SORT. The provided `best.pt` model is loaded by
+`main_tracking.py` to detect pigs in video files.
+
+## Setup
+
+Install the required dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Training
+
+Run the training script to train or fine tune the YOLOv8 model:
+
+```bash
+python train.py
+```
+
+## Tracking
+
+Use `main_tracking.py` to run object tracking on a video. The script expects the
+input video at `./data/dos_1.mp4` and writes the output video and tracking data
+to the project directory.
+
+```bash
+python main_tracking.py
+```

--- a/main_tracking.py
+++ b/main_tracking.py
@@ -16,7 +16,9 @@ fps = cap.get(cv2.CAP_PROP_FPS)  # Obtener los FPS del video
 
 cap_out = cv2.VideoWriter(video_out_path, cv2.VideoWriter_fourcc(*'MP4V'), fps, (frame.shape[1], frame.shape[0]))
 
-model = YOLO("D:\\TFM\\Tracker\\object-tracking-yolov8-deep-sort\\code\\best.pt")
+# Load YOLO model from the repository directory so it works cross-platform
+model_path = os.path.join(os.path.dirname(__file__), "best.pt")
+model = YOLO(model_path)
 tracker = Tracker()
 colors = [(random.randint(0, 255), random.randint(0, 255), random.randint(0, 255)) for j in range(10)]
 


### PR DESCRIPTION
## Summary
- load the model path relative to repo root in `main_tracking.py`
- document how to train and run the tracking demo

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686b0fade5e8832ea59cabb7ffc2093e